### PR TITLE
[assessment] Fix the TemplateSyntaxError

### DIFF
--- a/django-prosoul/prosoul/templates/prosoul/assessment_config.html
+++ b/django-prosoul/prosoul/templates/prosoul/assessment_config.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% if assessment %}
 {% if kibana_url %}
 <div class="row">


### PR DESCRIPTION
This PR fixes the `TemplateSyntaxError` caused by using `staticfiles` instead of `static` in the templates.

![Screenshot_20200326_033320](https://user-images.githubusercontent.com/25265451/77590916-da41dd00-6f14-11ea-8b53-f372bd937797.png)

```
{% load staticfiles %} and {% load admin_static %} are deprecated in favor of {% load static %}, which works the same.
```
Ref: https://docs.djangoproject.com/en/2.2/releases/2.1/#features-deprecated-in-2-1

